### PR TITLE
Get User By Id

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,13 +1,11 @@
 module Types
   class QueryType < Types::BaseObject
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
+    field :get_user, Types::UserType, null: false, description: 'Returns a single user by id' do
+      argument :id, ID, required: true
+    end
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    def get_user(id:)
+      User.find(id)
     end
   end
 end

--- a/app/graphql/types/recipe_type.rb
+++ b/app/graphql/types/recipe_type.rb
@@ -1,0 +1,15 @@
+module Types
+  class RecipeType < Types::BaseObject
+    field :id, ID, null: false
+    field :image, String, null: false
+    field :title, String, null: false
+    field :description, String, null: false
+    field :instructions, String, null: false
+    field :charity_id, String, null: false 
+    # ^^ Left this as a string for now as I'm not 100% sure on how charities will be handled
+    field :user_id, ID, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end
+  

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,18 @@
+module Types
+  class UserType < Types::BaseObject
+    field :id, ID, null: false
+    field :image, String, null: false
+    field :username, String, null: false
+    field :first_name, String, null: false
+    field :last_name, String, null: false
+    field :street, String, null: false
+    field :city, String, null: false
+    field :state, String, null: false
+    field :zip, String, null: false
+    field :billing_info, String, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :recipes, [Types::RecipeType], null: false
+  end
+end
+  

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,20 @@
 FactoryBot.define do
-    factory :user do
-        image { Faker::Avatar.image(slug: "my-own-slug", size: "50x50") }
-        username { Faker::Superhero.name }
-        password { '1234' }
-        first_name { Faker::Name.first_name }
-        last_name { Faker::Name.last_name }
-        street { Faker::Address.street_name }
-        city { Faker::Address.city }
-        state { Faker::Address.state_abbr }
-        zip { Faker::Address.zip }
-        billing_info { Faker::Stripe.valid_card }
-    end
-  end
+  factory :user do
+    image { Faker::Avatar.image(slug: "my-own-slug", size: "50x50") }
+    username { Faker::Superhero.name }
+    password { '1234' }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    street { Faker::Address.street_name }
+    city { Faker::Address.city }
+    state { Faker::Address.state_abbr }
+    zip { Faker::Address.zip }
+    billing_info { Faker::Stripe.valid_card }
+
+		trait :with_recipes do  
+    	after(:create) do |user|
+      create_list(:recipe, 3, user: user)
+      end
+		end 
+	end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'relationships' do
-    xit { should have_many :recipes }
+    it { should have_many :recipes }
     xit { should have_many :user_recipes }
   end
 

--- a/spec/queries/users/get_user_spec.rb
+++ b/spec/queries/users/get_user_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+module Queries
+  RSpec.describe Types::QueryType, type: :request do
+    before :each do
+      @user_1 = create(:user)
+      @user_2 = create(:user, :with_recipes)
+    end
+
+    def query(id:)
+      <<~GQL
+        query {
+          getUser(
+            id: #{id}
+          ) {
+            id
+            image
+            username
+            firstName
+            lastName
+            state
+            city
+            street
+            zip
+            billingInfo
+            createdAt
+            updatedAt
+            recipes {
+                id
+            }
+          }
+        }
+      GQL
+    end
+
+    it 'can get a single user without any recipes' do
+      post '/graphql', params: { query: query(id: @user_1.id) }
+
+      json = JSON.parse(response.body)
+
+      expect(json['data']['getUser']['id']).to eq(@user_1.id.to_s)
+      expect(json['data']['getUser']['image']).to eq(@user_1.image)
+      expect(json['data']['getUser']['username']).to eq(@user_1.username)
+      expect(json['data']['getUser']['firstName']).to eq(@user_1.first_name)
+      expect(json['data']['getUser']['lastName']).to eq(@user_1.last_name)
+      expect(json['data']['getUser']['street']).to eq(@user_1.street)
+      expect(json['data']['getUser']['city']).to eq(@user_1.city)
+      expect(json['data']['getUser']['state']).to eq(@user_1.state)
+      expect(json['data']['getUser']['zip']).to eq(@user_1.zip)
+      expect(json['data']['getUser']['billingInfo']).to eq(@user_1.billing_info)
+      expect(json['data']['getUser']['recipes']).to eq([])
+    end
+
+    it 'can get a single user with some recipes' do
+      post '/graphql', params: { query: query(id: @user_2.id) }
+
+      json = JSON.parse(response.body)
+
+      expect(json['data']['getUser']['id']).to eq(@user_2.id.to_s)
+      expect(json['data']['getUser']['image']).to eq(@user_2.image)
+      expect(json['data']['getUser']['username']).to eq(@user_2.username)
+      expect(json['data']['getUser']['firstName']).to eq(@user_2.first_name)
+      expect(json['data']['getUser']['lastName']).to eq(@user_2.last_name)
+      expect(json['data']['getUser']['street']).to eq(@user_2.street)
+      expect(json['data']['getUser']['city']).to eq(@user_2.city)
+      expect(json['data']['getUser']['state']).to eq(@user_2.state)
+      expect(json['data']['getUser']['zip']).to eq(@user_2.zip)
+      expect(json['data']['getUser']['billingInfo']).to eq(@user_2.billing_info)
+      expect(json['data']['getUser']['recipes'].size).to eq(3)
+      expect(json['data']['getUser']['recipes']).to match_array(
+        @user_2.recipes.map do |recipe|
+          { 'id' => recipe.id.to_s }
+        end
+      )
+    end
+  end
+end


### PR DESCRIPTION
Adds a query for getting a user by id. This query also gives the option to query a user's recipes too.
Added a trait to user factory so that a user with recipes can be created like this: `create(:user, :with_recipes)`

I'm thinking instead of hard coding a query we could just have the FE only query user_id of 1 and display that user's info, lmk what you think so I can either archive that ticket or build it.

closes #12 
